### PR TITLE
fix: Use dev-proven instance types for staging

### DIFF
--- a/.github/workflows/staging-train.yaml
+++ b/.github/workflows/staging-train.yaml
@@ -15,8 +15,8 @@ env:
   WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HUGGINGFACEHUB_API_TOKEN: ${{ secrets.HF_TOKEN }}
-  PREPROCESSING_INSTANCE_TYPE: ml.m5.xlarge
-  TRAINING_INSTANCE_TYPE: ml.g5.4xlarge
+  PREPROCESSING_INSTANCE_TYPE: ml.m5.large
+  TRAINING_INSTANCE_TYPE: ml.g5.12xlarge
   EVALUATION_INSTANCE_TYPE: ml.g5.xlarge
   DEPLOYMENT_INSTANCE_TYPE: ml.g4dn.xlarge
   BASE_IMAGE: 763104351884.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/pytorch-inference:2.0.1-gpu-py310-cu118-ubuntu20.04-sagemaker


### PR DESCRIPTION
- Training: ml.g5.4xlarge → ml.g5.12xlarge (matches dev, has quota)
- Preprocessing: ml.m5.xlarge → ml.m5.large (matches dev)
- Fixes quota error: 'ml.g5.4xlarge for processing job usage' is 0
- Uses proven configuration that worked in dev environment