### PR TITLE
Fix CausalLMCollator to respect tokenizer padding_side setting

### DIFF
--- a/src/nba_game_recap_summarizer/finetuning/data/nba_recap_dataset.py
+++ b/src/nba_game_recap_summarizer/finetuning/data/nba_recap_dataset.py
@@ -27,9 +27,10 @@ class CausalLMCollator:
                 raise ValueError("Batch not tokenized: expected 'input_ids' (and 'attention_mask').")
             inputs.append(item)
 
+        # Use the tokenizer's padding_side setting instead of hardcoded "longest"
         batch = self.tokenizer.pad(
             inputs,
-            padding="longest",
+            padding=True,  # Use True to respect tokenizer.padding_side
             pad_to_multiple_of=self.pad_to_multiple_of,
             return_tensors="pt",
         )


### PR DESCRIPTION
- Changed padding='longest' to padding=True to respect tokenizer.padding_side
- This fixes the right-padding warning during generation
- Should resolve the incoherent text generation issues