### PR TITLE
fix(dpo): align DPOTrainer args with TRL (use tokenizer=, drop proces…

### DIFF
--- a/src/nba_game_recap_summarizer/finetuning/dpo_tune.py
+++ b/src/nba_game_recap_summarizer/finetuning/dpo_tune.py
@@ -133,8 +133,7 @@ def dpo_tune(cfg) -> str:
         args=dpo_args,
         train_dataset=dpo_train,
         eval_dataset=dpo_eval,
-        processing_class=tokenizer,
-        peft_config=None,
+        tokenizer=tokenizer,
     )
 
     start = time.time()


### PR DESCRIPTION
…sing_class/peft_config) [skip ci]