### PR TITLE
fix(requirements): add sentence-transformers to DPO requirements

### DIFF
--- a/requirements-sagemaker-dpo.txt
+++ b/requirements-sagemaker-dpo.txt
@@ -33,3 +33,4 @@ requests
 psycopg2-binary
 huggingface_hub>=0.34.0
 sentencepiece>=0.1.99
+sentence-transformers>=2.2.0


### PR DESCRIPTION
- Add sentence-transformers>=2.2.0 to requirements-sagemaker-dpo.txt
- This fixes coherence_score and coverage_score being 0.0 in evaluation
- NarrativeStyleEvaluator requires sentence-transformers for embedding-based metrics

The logs showed 'SentenceTransformer model not available for coherence calculation' which was causing coherence_score and coverage_score to always be 0.0. [skip ci]